### PR TITLE
Fix Base.hash to not use default argument

### DIFF
--- a/src/Multisets.jl
+++ b/src/Multisets.jl
@@ -258,7 +258,7 @@ display(M::Multiset) = print(string(M))
 
 
 
-function hash(M::Multiset, h::UInt = UInt(0))
+function hash(M::Multiset, h::UInt)
     clean!(M)
     return hash(M.data, h)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -50,6 +50,7 @@ B = Multiset(1, 2, 3, 4)
 B[4] = 0
 @test A == B
 @test hash(A) == hash(B)
+@test hash(A, UInt(42)) == hash(B, UInt(42))
 
 set_key_value_show()
 A = Multiset(1, 1, 1, 2, 1, 3, 3)


### PR DESCRIPTION
Generated as part of an ecosystem-wide audit for one-arg hash methods.

\`Base.hash\` should only be extended via the two-arg method \`hash(x, h::UInt)\`.
The second argument should not be given a default value, as this implicitly
defines a one-arg method with a hard-coded seed. This can lead to correctness
bugs (hash contract violations when the seed differs from the hard-coded
default) and invalidation-related performance issues. This is particularly
necessary for Julia 1.13+ where the default hash seed value will change.

This PR was generated with the assistance of generative AI.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>